### PR TITLE
(BIZ-5715) Reverted target Framework version to 4.5 - for Agents 

### DIFF
--- a/Aims.Sdk.ExampleAgent/Aims.Sdk.ExampleAgent.csproj
+++ b/Aims.Sdk.ExampleAgent/Aims.Sdk.ExampleAgent.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Aims.Sdk.ExampleAgent</RootNamespace>
     <AssemblyName>Aims.Sdk.ExampleAgent</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Aims.Sdk.ExampleAgent/App.config
+++ b/Aims.Sdk.ExampleAgent/App.config
@@ -5,4 +5,4 @@
     <add key="environment-id" value=""/>
     <add key="token" value=""/>
   </appSettings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/Aims.Sdk/Aims.Sdk.csproj
+++ b/Aims.Sdk/Aims.Sdk.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Aims.Sdk</RootNamespace>
     <AssemblyName>Aims.Sdk</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>


### PR DESCRIPTION
This revision addresses a problem hit by a (potential) customer (inter???, who are still on .NET 
framework version 4.5) when running the MsSql agent installer: 
  Runtime version error running the MsSql agent installer :  
      "This application requires" ... ".NETFramework,Version=v4.6.1"

All references to .NET Framwork v4.6.1 -in all projects and all subpackages- have been 
replaced by v4.5                                                                                                                                                                                                                                                                                                                                              This problem could become more wide spread - as more customers come to pick up our latest 
releases - and shows that going with the latest & greatest Framework (and other) versions is not
always a good idea. The NuGet generated should become the new de facto standard version installed 
in all the agent installers.